### PR TITLE
FIX: Typo and Verb Use

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -78,7 +78,7 @@ Next, the local `.env` needs to be modified to match the current host environmen
 $ cp .env.example .env
 $ vi .env
 ```
-* Assign APP_URL with the URL that your webserver uses connects to your public documents folder (step-1, above)
+* Assign APP_URL with the URL that your webserver uses to connect to your public documents folder (step-1, above)
 * Assign database credentials (a user with rights to create databases and grant privileges):
     * DB_USERNAME, DB_PASSWORD, DB_USERNAME2, DB_PASSWORD2
 * Update settings for connecting to email and SMTP services (will vary depending on server environment). These

--- a/app/Console/Commands/ConsortiumCommand.php
+++ b/app/Console/Commands/ConsortiumCommand.php
@@ -129,7 +129,7 @@ class ConsortiumCommand extends Command
         $this->line('<fg=cyan>Consortium added to global database.');
 
       // Create the Administrator account in the users table
-        $this->info('The initial Administrator acccount for a new consortium is always created with');
+        $this->info('The initial Administrator account for a new consortium is always created with');
         $this->info('an email address set to "Administrator".');
         // Not sure this should be secret... if they typo it, it's difficult to reset
         $_pass = $this->ask('Enter a password for this Administrator account?');


### PR DESCRIPTION
This PR:
- adjusts the verb usage in Step 3 of the installation docs for clarity
- fixes a typo in a user-facing informational message 
